### PR TITLE
fix(script/setup): update scripts for ubuntu 22.04

### DIFF
--- a/setup/scripts/download-ansible.sh
+++ b/setup/scripts/download-ansible.sh
@@ -12,7 +12,7 @@ set -e
 
 # === Configuration ===
 UBUNTU_VERSIONS=("jammy")  # Only Ubuntu 22.04
-DEB_PACKAGES=(python3.10-venv python3-pip)
+DEB_PACKAGES=(python3.10-venv python3-pip sshpass)
 ANSIBLE_VER="9.8.0"
 ANSIBLE_CORE_VER="2.16.9"
 OUTPUT_DIR="offline_ansible"

--- a/setup/scripts/download-slurm-pkgs-deb.sh
+++ b/setup/scripts/download-slurm-pkgs-deb.sh
@@ -7,6 +7,11 @@ OUT="offline_repo"
 mkdir -p "$OUT"
 
 # 패키지 그룹 정의
+NFS_PKGS=(
+  nfs-common
+  nfs-kernel-server
+)
+
 COMMON_PKGS=(
   build-essential
   python3
@@ -30,10 +35,15 @@ PMIX_DEP_PKGS=(
 SLURM_DEP_PKGS=(
   libmunge-dev
   libmariadb-dev
-  libmariadbclient-dev-compat
+  libmariadb-dev-compat
   libpam0g-dev
   libdbus-1-dev
   ruby-dev
+  mariadb-server
+  python3-pymysql
+  mailutils
+  policykit-1
+  numactl
 )
 
 OPENMPI_DEP_PKGS=(
@@ -48,6 +58,8 @@ ENROOT_DEP_PKGS=(
   pigz
   enroot
   enroot+caps
+  jq
+  parallel
 )
 
 download_group() {
@@ -72,6 +84,7 @@ download_group() {
 }
 
 # 실행
+download_group nfs "${NFS_PKGS[@]}"
 download_group common "${COMMON_PKGS[@]}"
 download_group munge "${MUNGE_PKGS[@]}"
 download_group enroot "${ENROOT_DEP_PKGS[@]}"

--- a/setup/scripts/download-source-packages.sh
+++ b/setup/scripts/download-source-packages.sh
@@ -11,7 +11,7 @@ hwloc_version="${hwloc_minor_version}.0"
 pmix_version="3.2.3"
 openmpi_minor_version="4.0"
 openmpi_version="${openmpi_minor_version}.3"
-slurm_version="24.11.0"
+slurm_version="23.02.4"
 pyxis_version="0.11.1"
 enroot_version="3.5.0"
 

--- a/setup/scripts/setup-nfs-repo.sh
+++ b/setup/scripts/setup-nfs-repo.sh
@@ -13,7 +13,10 @@ for target in "${REPO_ROOT[@]}"; do
     fi
 
     echo "📦 Create index in: $dir"
-    dpkg-scanpackages "$dir" /dev/null | tee "$dir/Packages" | gzip -9c > "$dir/Packages.gz"
+    (
+      cd "$dir"
+      dpkg-scanpackages . /dev/null | tee "Packages" | gzip -9c > "Packages.gz"
+    )
   done
 done
 


### PR DESCRIPTION
update scripts for ubuntu 22.04
- ansible machine 셋업
    - 필요 패키지 추가 - `sshpass`
- download 스크립트
    - nfs 패키지도 포함하여 일괄 다운로드하도록 변경
    - 패키지명 변경 (22.04 기준)
        - `libmariadbclient-dev-compat` -> `libmariadb-dev-compat`
    - 필요 패키지 추가 - slurm dependency
            - `mariadb-server` - `python3-pymysql` - `mailutils` - `policykit-1` - `numactl`
        - openmpi dependency - `jq` - `parallel`
- 인덱스 생성 스크립트 수정

### Related issues 
- #31