### PR TITLE
fix(munge): distribute key from controller node

### DIFF
--- a/playbooks/roles/munge/tasks/main.yml
+++ b/playbooks/roles/munge/tasks/main.yml
@@ -1,4 +1,3 @@
-
 - name: Install Munge (RedHat-based)
   ansible.builtin.yum:
     name:
@@ -31,15 +30,30 @@
   ansible.builtin.command: /usr/sbin/create-munge-key
   when: inventory_hostname == groups['controller'][0] and not munge_key.stat.exists
 
-- name: Deploy munge key
+- name: Read munge key from controller
+  ansible.builtin.slurp:
+    src: /etc/munge/munge.key
+  delegate_to: "{{ groups['controller'][0] }}"
+  run_once: true
+  register: munge_key_content
+  no_log: true
+
+- name: Deploy munge key to non-controller nodes
   ansible.builtin.copy:
-    src: "/etc/munge/munge.key"
-    dest: "/etc/munge/munge.key"
+    content: "{{ munge_key_content.content | b64decode }}"
+    dest: /etc/munge/munge.key
     owner: munge
     group: munge
     mode: '0400'
-    remote_src: yes
   when: inventory_hostname != groups['controller'][0]
+  no_log: true
+
+- name: Ensure munge key permissions are correct
+  ansible.builtin.file:
+    path: /etc/munge/munge.key
+    owner: munge
+    group: munge
+    mode: '0400'
 
 - name: Start and enable Munge service
   ansible.builtin.service:


### PR DESCRIPTION
## Summary
- read munge.key from the controller node after key generation
- distribute the key to non-controller nodes with copy content instead of remote_src
- enforce munge.key ownership and permissions after distribution

## Testing
- not run (ansible-playbook unavailable and local yaml tooling incomplete)